### PR TITLE
Upgrade codecov action to v2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,6 @@ jobs:
         if: matrix.coverage
       - name: Send coverage
         if: matrix.coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           file: lcov.info


### PR DESCRIPTION
Currently getting this issue:
https://community.codecov.com/t/codecov-github-action-fails-could-not-find-a-repository-try-using-upload-token/3081