### PR TITLE
fix SVGP deprecation: now gives Centered representation as it should have for backwards compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ApproximateGPs"
 uuid = "298c2ebc-0411-48ad-af38-99e88101b606"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.2.6"
+version = "0.2.7"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,1 +1,1 @@
-@deprecate SVGP SparseVariationalApproximation
+@deprecate SVGP(args...) SparseVariationalApproximation(Centered(), args...)


### PR DESCRIPTION
Resolves #88 

NB- https://github.com/JuliaGaussianProcesses/ApproximateGPs.jl/releases/tag/v0.2.2 was the one changing the default from Centered() to NonCentered() so should've been marked as breaking, whereas v0.2.0 didn't actually _break_ anything (as there was the `@deprecate SVGP ...`)...