### PR TITLE
Fix file size of notebook

### DIFF
--- a/examples/a-regression/script.jl
+++ b/examples/a-regression/script.jl
@@ -12,10 +12,15 @@
 using ApproximateGPs
 using Distributions
 using LinearAlgebra
-#jl using DisplayAs
 
 using Plots
+## We save plots as PNG files to reduce their size
 default(; fmt=:png, palette=:seaborn_colorblind, legend=:outertopright, size=(700, 400))
+#nb
+#nb ## Regardless of the `fmt` setting above, by default in notebooks Literate also saves
+#nb ## the SVG output: https://github.com/fredrikekre/Literate.jl/issues/61
+#nb ## We use DisplayAs to ensure that only the PNG output is saved.
+#nb using DisplayAs
 
 using Random
 Random.seed!(1234);
@@ -30,10 +35,10 @@ N = 10000 # Number of training points
 x = rand(Uniform(-1, 1), N)
 y = g.(x) + 0.3 * randn(N)
 
-plt = scatter(
+scatter(
     x, y; xlabel="x", ylabel="y", markershape=:xcross, markeralpha=0.1, legend=false
 )
-#jl DisplayAs.PNG(plt)
+#nb DisplayAs.PNG(current())
 
 # ## Set up a Flux model
 #
@@ -149,7 +154,7 @@ model = SVGPModel(k_init, z_init, m_init, A_init);
 # very poor fit to the data, as expected:
 
 init_post = model_posterior(model)
-plt = scatter(
+scatter(
     x,
     y;
     xlabel="x",
@@ -158,8 +163,8 @@ plt = scatter(
     markeralpha=0.1,
     label="Training Data",
 )
-plot!(plt, -1:0.001:1, init_post; label="Initial Posterior", color=4)
-#jl DisplayAs.PNG(plt)
+plot!(-1:0.001:1, init_post; label="Initial Posterior", color=4)
+#nb DisplayAs.PNG(current())
 
 # ## Training the model
 #
@@ -200,7 +205,7 @@ loss(model, x, y)
 
 post = model_posterior(model)
 
-plt = scatter(
+scatter(
     x,
     y;
     markershape=:xcross,
@@ -212,6 +217,6 @@ plt = scatter(
     label="Training Data",
     color=1,
 )
-plot!(plt, -1:0.001:1, post; label="Posterior", color=4)
-sticks!(plt, model.z, fill(0.13, M); label="Pseudo-points", linewidth=1.5, color=5)
-#jl DisplayAs.PNG(plt)
+plot!(-1:0.001:1, post; label="Posterior", color=4)
+sticks!(model.z, fill(0.13, M); label="Pseudo-points", linewidth=1.5, color=5)
+#nb DisplayAs.PNG(current())

--- a/examples/a-regression/script.jl
+++ b/examples/a-regression/script.jl
@@ -35,9 +35,7 @@ N = 10000 # Number of training points
 x = rand(Uniform(-1, 1), N)
 y = g.(x) + 0.3 * randn(N)
 
-scatter(
-    x, y; xlabel="x", ylabel="y", markershape=:xcross, markeralpha=0.1, legend=false
-)
+scatter(x, y; xlabel="x", ylabel="y", markershape=:xcross, markeralpha=0.1, legend=false)
 #nb DisplayAs.PNG(current())
 
 # ## Set up a Flux model

--- a/examples/a-regression/script.jl
+++ b/examples/a-regression/script.jl
@@ -14,11 +14,10 @@ using Distributions
 using LinearAlgebra
 
 using Plots
-## We save plots as PNG files to reduce their size
+## We output plots as PNG to reduce their size
 default(; fmt=:png, palette=:seaborn_colorblind, legend=:outertopright, size=(700, 400))
-#nb
-#nb ## Regardless of the `fmt` setting above, by default in notebooks Literate also saves
-#nb ## the SVG output: https://github.com/fredrikekre/Literate.jl/issues/61
+#nb ## Regardless of the `fmt` setting, by default Literate saves also the SVG output
+#nb ## in notebooks: https://github.com/fredrikekre/Literate.jl/issues/61
 #nb ## We use DisplayAs to ensure that only the PNG output is saved.
 #nb using DisplayAs
 


### PR DESCRIPTION
Fixes the file size of the notebook (currently 21MB) and replaces https://github.com/JuliaGaussianProcesses/ApproximateGPs.jl/pull/102.

Edit: With this PR file size is 588kB: https://github.com/JuliaGaussianProcesses/ApproximateGPs.jl/blob/gh-pages/previews/PR103/examples/a-regression.ipynb.