### PR TITLE
Fix outdated `literate.jl` script

### DIFF
--- a/docs/literate.jl
+++ b/docs/literate.jl
@@ -86,21 +86,15 @@ function preprocess(content)
     return content * append
 end
 
-function md_postprocess(content)
-    return replace(content, r"[\n]nothing #hide$"m => "")
-end
-
 # Convert to markdown and notebook
 const SCRIPTJL = joinpath(EXAMPLEPATH, "script.jl")
 Literate.markdown(
     SCRIPTJL,
     OUTDIR;
     name=EXAMPLE,
-    documenter=true,
     execute=true,
     preprocess=preprocess,
-    postprocess=md_postprocess,
 )
 Literate.notebook(
-    SCRIPTJL, OUTDIR; name=EXAMPLE, documenter=true, execute=true, preprocess=preprocess
+    SCRIPTJL, OUTDIR; name=EXAMPLE, execute=true, preprocess=preprocess
 )


### PR DESCRIPTION
This PR fixes some outdated stuff in the `literate.jl`, independently of the other PRs concerning examples/Literate/Documenter:
- The `nothing #hide` bug was fixed in https://github.com/fredrikekre/Literate.jl/pull/188
- `documenter=...` is deprecated, instead one should specify the Markdown flavour. Since for Markdown the default is `DocumenterFlavour`, I removed the keyword argument
- `documenter=...` is ignored for notebook output, so I removed the keyword argument there as well