### PR TITLE
bump version back to 0.3.3, which did not get released yet

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ApproximateGPs"
 uuid = "298c2ebc-0411-48ad-af38-99e88101b606"
 authors = ["JuliaGaussianProcesses Team"]
-version = "0.3.4"
+version = "0.3.3"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"


### PR DESCRIPTION
We had missed a [compat] entry for 0.3.3, which [prevented the registrator automerge](https://github.com/JuliaRegistries/General/pull/56764#issuecomment-1070957850), so I fixed that for 0.3.4, but the missing 0.3.3 [prevented the automerge of that](https://github.com/JuliaRegistries/General/pull/56766#issuecomment-1071019368). It seems easiest to simply change the version back to 0.3.3 (which had not gotten released yet), and then register _this_ (and close the two open registry PRs linked above).