### PR TITLE
Factor out homoscadasticity check in elbo

### DIFF
--- a/src/SparseVariationalApproximationModule.jl
+++ b/src/SparseVariationalApproximationModule.jl
@@ -367,7 +367,7 @@ function _get_homoscedastic_noise(_)
     return error(
         "The observation noise fx.Σy must be homoscedastic.\n",
         "To avoid this error, construct fx using: f = GP(kernel); fx = f(x, σ²)",
-        ", where σ² is a positive Real.\n"
+        ", where σ² is a positive Real.\n",
     )
 end
 

--- a/src/SparseVariationalApproximationModule.jl
+++ b/src/SparseVariationalApproximationModule.jl
@@ -312,7 +312,6 @@ function AbstractGPs.elbo(
     quadrature=DefaultExpectationMethod(),
 )
     σ² = _get_homoscedastic_noise(fx.Σy)
-    σ² = fx.Σy[1]
     lik = GaussianLikelihood(σ²)
     return elbo(sva, LatentFiniteGP(fx, lik), y; num_data, quadrature)
 end


### PR DESCRIPTION
Relaxes the type signature of `elbo` to make it possible to extend