### PR TITLE
Use `Flux.Adam` instead of `Flux.ADAM`

### DIFF
--- a/test/SparseVariationalApproximationModule.jl
+++ b/test/SparseVariationalApproximationModule.jl
@@ -172,7 +172,7 @@
 
             # Train the SVGP model
             data = [(x, y)]
-            opt = Flux.ADAM(0.001)
+            opt = Flux.Adam(0.001)
 
             svgp_ps = Flux.params(svgp_model)
 


### PR DESCRIPTION
Fixes a deprecation warning.

Side note: there seem to be some new failures of SVA due to upstream changes.