### PR TITLE
Update CompatHelper.yml

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -14,7 +14,7 @@ jobs:
           import Pkg
           name = "CompatHelper"
           uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
-          version = "2"
+          version = "3"
           Pkg.add(; name, uuid, version)
         shell: julia --color=yes {0}
       - name: "Run CompatHelper"


### PR DESCRIPTION
Seems CompatHelper has been failing for quite some time. Updating it to version 3 should fix these issues.

Manually triggered run on this PR: https://github.com/JuliaGaussianProcesses/ApproximateGPs.jl/actions/runs/3127478414/jobs/5074144694